### PR TITLE
Archipack: Added preview thumbnail size to preferences dialog.

### DIFF
--- a/archipack/__init__.py
+++ b/archipack/__init__.py
@@ -180,6 +180,19 @@ class Archipack_Pref(AddonPreferences):
         size=4,
         min=0, max=1
     )
+    # Thumbnail preview size
+    thumb_size_x: IntProperty(
+        name="Thumbnail width",
+        description="Thumbnail width (pixels)",
+        min=24,
+        default=150
+    )
+    thumb_size_y: IntProperty(
+        name="Thumbnail height",
+        description="Thumbnail height (pixels)",
+        min=24,
+        default=100
+    )
     matlib_path : StringProperty(
             name="Folder path",
             description="absolute path to material library folder",
@@ -299,6 +312,9 @@ class Archipack_Pref(AddonPreferences):
         col.prop(self, "handle_size")
         col.prop(self, "text_size")
         col.prop(self, "constant_handle_size")
+        col.label(text="Thumbnails:")
+        col.prop(self, "thumb_size_x")
+        col.prop(self, "thumb_size_y")
 
 # ----------------------------------------------------
 # Archipack panel

--- a/archipack/archipack_preset.py
+++ b/archipack/archipack_preset.py
@@ -211,10 +211,13 @@ class PresetMenu():
             'LEFT_ARROW', 'RIGHT_ARROW'
             }
 
-    def __init__(self, context, category, thumbsize=Vector((150, 100))):
+    def __init__(self, context, category):
+    
+        # get thumbsize from preferences
+        prefs = context.preferences.addons[__name__.split('.')[0]].preferences
+        self.thumbsize=Vector((prefs.thumb_size_x, prefs.thumb_size_y))
         self.imageList = []
         self.menuItems = []
-        self.thumbsize = thumbsize
         file_list = self.scan_files(category)
         self.default_image = None
         self.load_default_image()


### PR DESCRIPTION
Useful for 4k (and higher) monitor resolution.
The rendered thumbnails won't be changed. This will only **scale** the existing thumbs for preview.