### PR TITLE
Fix SVG material cache bug

### DIFF
--- a/io_curve_svg/import_svg.py
+++ b/io_curve_svg/import_svg.py
@@ -197,9 +197,6 @@ def SVGGetMaterial(color, context):
     materials = context['materials']
     rgb_re = re.compile('^\s*rgb\s*\(\s*(\d+)\s*,\s*(\d+)\s*,(\d+)\s*\)\s*$')
 
-    if color in materials:
-        return materials[color]
-
     diff = None
     if color.startswith('#'):
         color = color[1:]
@@ -215,6 +212,9 @@ def SVGGetMaterial(color, context):
         diff = (float(c[0]), float(c[1]), float(c[2]))
     else:
         return None
+      
+    if color in materials:
+        return materials[color]      
 
     diffuse_color = ([x / 255.0 for x in diff])
 


### PR DESCRIPTION
This fixes a bug that causes a new material to be created for every color even if it has been cached. The color name is transformed and then used as a key for the cache, but the cache was being checked against the pre-transformed version, causing it to fail every time. This fix makes sure the key being looked for in the cache has been transformed, and can therefore be found as expected.