### PR TITLE
Fix failing import of VRML2 files that have no coord/coordIndex section in a Shape node

### DIFF
--- a/io_scene_x3d/import_x3d.py
+++ b/io_scene_x3d/import_x3d.py
@@ -1891,6 +1891,10 @@ def importMesh_IndexedFaceSet(geom, ancestry):
 
     ccw = geom.getFieldAsBool('ccw', True, ancestry)
     coord = geom.getChildBySpec('Coordinate')
+
+    if coord is None:
+        return None
+
     if coord.reference:
         points = coord.getRealNode().parsed
         # We need unflattened coord array here, while
@@ -3152,6 +3156,10 @@ def importShape(bpycollection, node, ancestry, global_matrix):
     geom_fn = geometry_importers.get(geom_spec)
     if geom_fn is not None:
         bpydata = geom_fn(geom, ancestry)
+
+        if bpydata is None:
+            print('\tImportX3D warning: empty shape, skipping node "%s"' % vrmlname)
+            return
 
         # There are no geometry importers that can legally return
         # no object.  It's either a bpy object, or an exception


### PR DESCRIPTION
Import of VRML2 files that have empty Shape node sections in the file currently fails. Other VRML2 Viewers and Importers handle this kind of file fine.

This is a small proposed change that adds missing checks for NoneType and ignores those empty shape nodes.
Regardless of what the preferred handling of the empty shape nodes is, the NoneType check added in lines 1894-1897 is needed because geom.getChildBySpec can return None.