### PR TITLE
Naive fix for non-selected armature and animation exports.

### DIFF
--- a/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -181,7 +181,7 @@ def __gather_children(blender_object, blender_scene, export_settings):
                 children.append(node)
 
     # blender bones
-    if blender_object.type == "ARMATURE":
+    if blender_object.type == "ARMATURE" and __filter_node(blender_object, blender_scene, export_settings):
         root_joints = []
         if export_settings["gltf_def_bones"] is False:
             bones = blender_object.pose.bones


### PR DESCRIPTION
Current GLTF exporter pulls in ALL animations and associated bones even when "Include > Selected Objects" is chosen. This fix uses the same logic as ```gather_node``` to filter exported objects.

Related: https://developer.blender.org/T84506