### PR TITLE
Added feature to shift large coordinates

### DIFF
--- a/io_scene_obj/__init__.py
+++ b/io_scene_obj/__init__.py
@@ -41,18 +41,18 @@ if "bpy" in locals():
 
 import bpy
 from bpy.props import (
-    BoolProperty,
-    FloatProperty,
-    StringProperty,
-    EnumProperty,
-)
+        BoolProperty,
+        FloatProperty,
+        StringProperty,
+        EnumProperty,
+        )
 from bpy_extras.io_utils import (
-    ImportHelper,
-    ExportHelper,
-    orientation_helper,
-    path_reference_mode,
-    axis_conversion,
-)
+        ImportHelper,
+        ExportHelper,
+        orientation_helper,
+        path_reference_mode,
+        axis_conversion,
+        )
 
 
 @orientation_helper(axis_forward='-Z', axis_up='Y')
@@ -64,60 +64,77 @@ class ImportOBJ(bpy.types.Operator, ImportHelper):
 
     filename_ext = ".obj"
     filter_glob: StringProperty(
-        default="*.obj;*.mtl",
-        options={'HIDDEN'},
-    )
+            default="*.obj;*.mtl",
+            options={'HIDDEN'},
+            )
 
     use_edges: BoolProperty(
-        name="Lines",
-        description="Import lines and faces with 2 verts as edge",
-        default=True,
-    )
+            name="Lines",
+            description="Import lines and faces with 2 verts as edge",
+            default=True,
+            )
     use_smooth_groups: BoolProperty(
-        name="Smooth Groups",
-        description="Surround smooth groups by sharp edges",
-        default=True,
-    )
+            name="Smooth Groups",
+            description="Surround smooth groups by sharp edges",
+            default=True,
+            )
 
     use_split_objects: BoolProperty(
-        name="Object",
-        description="Import OBJ Objects into Blender Objects",
-        default=True,
-    )
+            name="Object",
+            description="Import OBJ Objects into Blender Objects",
+            default=True,
+            )
     use_split_groups: BoolProperty(
-        name="Group",
-        description="Import OBJ Groups into Blender Objects",
-        default=False,
-    )
+            name="Group",
+            description="Import OBJ Groups into Blender Objects",
+            default=False,
+            )
 
     use_groups_as_vgroups: BoolProperty(
-        name="Poly Groups",
-        description="Import OBJ groups as vertex groups",
-        default=False,
-    )
+            name="Poly Groups",
+            description="Import OBJ groups as vertex groups",
+            default=False,
+            )
 
     use_image_search: BoolProperty(
-        name="Image Search",
-        description="Search subdirs for any associated images "
-        "(Warning, may be slow)",
-        default=True,
-    )
+            name="Image Search",
+            description="Search subdirs for any associated images "
+                        "(Warning, may be slow)",
+            default=True,
+            )
 
     split_mode: EnumProperty(
-        name="Split",
-        items=(
-            ('ON', "Split", "Split geometry, omits vertices unused by edges or faces"),
-            ('OFF', "Keep Vert Order", "Keep vertex order from file"),
-        ),
-    )
+            name="Split",
+            items=(('ON', "Split", "Split geometry, omits unused verts"),
+                   ('OFF', "Keep Vert Order", "Keep vertex order from file"),
+                   ),
+            )
 
     global_clamp_size: FloatProperty(
-        name="Clamp Size",
-        description="Clamp bounds under this value (zero to disable)",
-        min=0.0, max=1000.0,
-        soft_min=0.0, soft_max=1000.0,
-        default=0.0,
-    )
+            name="Clamp Size",
+            description="Clamp bounds under this value (zero to disable)",
+            min=0.0, max=1000.0,
+            soft_min=0.0, soft_max=1000.0,
+            default=0.0,
+            )
+
+    global_shift_x: FloatProperty(
+            name="Shift on x axis",
+            description="Shift value to apply to x axis (assuming a z up yforward world)",
+            default=0.0,
+            )
+
+    global_shift_y: FloatProperty(
+            name="Shift on y axis",
+            description="Shift value to apply to y axis (assuming a z up yforward world)",
+            default=0.0,
+            )     
+
+    global_shift_z: FloatProperty(
+            name="Shift on z axis",
+            description="Shift value to apply to z axis (assuming a z up yforward world)",
+            default=0.0,
+            )
 
     def execute(self, context):
         # print("Selected: " + context.active_object.name)
@@ -129,19 +146,15 @@ class ImportOBJ(bpy.types.Operator, ImportHelper):
         else:
             self.use_groups_as_vgroups = False
 
-        keywords = self.as_keywords(
-            ignore=(
-                "axis_forward",
-                "axis_up",
-                "filter_glob",
-                "split_mode",
-            ),
-        )
+        keywords = self.as_keywords(ignore=("axis_forward",
+                                            "axis_up",
+                                            "filter_glob",
+                                            "split_mode",
+                                            ))
 
-        global_matrix = axis_conversion(
-            from_forward=self.axis_forward,
-            from_up=self.axis_up,
-        ).to_4x4()
+        global_matrix = axis_conversion(from_forward=self.axis_forward,
+                                        from_up=self.axis_up,
+                                        ).to_4x4()
         keywords["global_matrix"] = global_matrix
 
         if bpy.data.is_saved and context.preferences.filepaths.use_relative_paths:
@@ -204,6 +217,9 @@ class OBJ_PT_import_transform(bpy.types.Panel):
         layout.prop(operator, "global_clamp_size")
         layout.prop(operator, "axis_forward")
         layout.prop(operator, "axis_up")
+        layout.prop(operator, "global_shift_x")
+        layout.prop(operator, "global_shift_y")
+        layout.prop(operator, "global_shift_z")
 
 
 class OBJ_PT_import_geometry(bpy.types.Panel):
@@ -249,104 +265,130 @@ class ExportOBJ(bpy.types.Operator, ExportHelper):
 
     filename_ext = ".obj"
     filter_glob: StringProperty(
-        default="*.obj;*.mtl",
-        options={'HIDDEN'},
-    )
+            default="*.obj;*.mtl",
+            options={'HIDDEN'},
+            )
 
     # context group
     use_selection: BoolProperty(
-        name="Selection Only",
-        description="Export selected objects only",
-        default=False,
-    )
+            name="Selection Only",
+            description="Export selected objects only",
+            default=False,
+            )
     use_animation: BoolProperty(
-        name="Animation",
-        description="Write out an OBJ for each frame",
-        default=False,
-    )
+            name="Animation",
+            description="Write out an OBJ for each frame",
+            default=False,
+            )
 
     # object group
     use_mesh_modifiers: BoolProperty(
-        name="Apply Modifiers",
-        description="Apply modifiers",
-        default=True,
-    )
+            name="Apply Modifiers",
+            description="Apply modifiers",
+            default=True,
+            )
+    # Non working in Blender 2.8 currently.
+    # ~ use_mesh_modifiers_render: BoolProperty(
+            # ~ name="Use Modifiers Render Settings",
+            # ~ description="Use render settings when applying modifiers to mesh objects",
+            # ~ default=False,
+            # ~ )
+
     # extra data group
     use_edges: BoolProperty(
-        name="Include Edges",
-        description="",
-        default=True,
-    )
+            name="Include Edges",
+            description="",
+            default=True,
+            )
     use_smooth_groups: BoolProperty(
-        name="Smooth Groups",
-        description="Write sharp edges as smooth groups",
-        default=False,
-    )
+            name="Smooth Groups",
+            description="Write sharp edges as smooth groups",
+            default=False,
+            )
     use_smooth_groups_bitflags: BoolProperty(
-        name="Bitflag Smooth Groups",
-        description="Same as 'Smooth Groups', but generate smooth groups IDs as bitflags "
-        "(produces at most 32 different smooth groups, usually much less)",
-        default=False,
-    )
+            name="Bitflag Smooth Groups",
+            description="Same as 'Smooth Groups', but generate smooth groups IDs as bitflags "
+                        "(produces at most 32 different smooth groups, usually much less)",
+            default=False,
+            )
     use_normals: BoolProperty(
-        name="Write Normals",
-        description="Export one normal per vertex and per face, to represent flat faces and sharp edges",
-        default=True,
-    )
+            name="Write Normals",
+            description="Export one normal per vertex and per face, to represent flat faces and sharp edges",
+            default=True,
+            )
     use_uvs: BoolProperty(
-        name="Include UVs",
-        description="Write out the active UV coordinates",
-        default=True,
-    )
+            name="Include UVs",
+            description="Write out the active UV coordinates",
+            default=True,
+            )
     use_materials: BoolProperty(
-        name="Write Materials",
-        description="Write out the MTL file",
-        default=True,
-    )
+            name="Write Materials",
+            description="Write out the MTL file",
+            default=True,
+            )
     use_triangles: BoolProperty(
-        name="Triangulate Faces",
-        description="Convert all faces to triangles",
-        default=False,
-    )
+            name="Triangulate Faces",
+            description="Convert all faces to triangles",
+            default=False,
+            )
     use_nurbs: BoolProperty(
-        name="Write Nurbs",
-        description="Write nurbs curves as OBJ nurbs rather than "
-        "converting to geometry",
-        default=False,
-    )
+            name="Write Nurbs",
+            description="Write nurbs curves as OBJ nurbs rather than "
+                        "converting to geometry",
+            default=False,
+            )
     use_vertex_groups: BoolProperty(
-        name="Polygroups",
-        description="",
-        default=False,
-    )
+            name="Polygroups",
+            description="",
+            default=False,
+            )
 
     # grouping group
     use_blen_objects: BoolProperty(
-        name="OBJ Objects",
-        description="Export Blender objects as OBJ objects",
-        default=True,
-    )
+            name="OBJ Objects",
+            description="Export Blender objects as OBJ objects",
+            default=True,
+            )
     group_by_object: BoolProperty(
-        name="OBJ Groups",
-        description="Export Blender objects as OBJ groups",
-        default=False,
-    )
+            name="OBJ Groups",
+            description="Export Blender objects as OBJ groups",
+            default=False,
+            )
     group_by_material: BoolProperty(
-        name="Material Groups",
-        description="Generate an OBJ group for each part of a geometry using a different material",
-        default=False,
-    )
+            name="Material Groups",
+            description="Generate an OBJ group for each part of a geometry using a different material",
+            default=False,
+            )
     keep_vertex_order: BoolProperty(
-        name="Keep Vertex Order",
-        description="",
-        default=False,
-    )
+            name="Keep Vertex Order",
+            description="",
+            default=False,
+            )
 
     global_scale: FloatProperty(
-        name="Scale",
-        min=0.01, max=1000.0,
-        default=1.0,
-    )
+            name="Scale",
+            min=0.01, max=1000.0,
+            default=1.0,
+            )
+
+
+    global_shift_x: FloatProperty(
+            name="Shift on x axis",
+            description="Shift value to apply to x axis (assuming a z up yforward world)",
+            default=0.0,
+            )
+
+    global_shift_y: FloatProperty(
+            name="Shift on y axis",
+            description="Shift value to apply to y axis (assuming a z up yforward world)",
+            default=0.0,
+            )     
+
+    global_shift_z: FloatProperty(
+            name="Shift on z axis",
+            description="Shift value to apply to z axis (assuming a z up yforward world)",
+            default=0.0,
+            )
 
     path_mode: path_reference_mode
 
@@ -356,23 +398,17 @@ class ExportOBJ(bpy.types.Operator, ExportHelper):
         from . import export_obj
 
         from mathutils import Matrix
-        keywords = self.as_keywords(
-            ignore=(
-                "axis_forward",
-                "axis_up",
-                "global_scale",
-                "check_existing",
-                "filter_glob",
-            ),
-        )
+        keywords = self.as_keywords(ignore=("axis_forward",
+                                            "axis_up",
+                                            "global_scale",
+                                            "check_existing",
+                                            "filter_glob",
+                                            ))
 
-        global_matrix = (
-            Matrix.Scale(self.global_scale, 4) @
-            axis_conversion(
-                to_forward=self.axis_forward,
-                to_up=self.axis_up,
-            ).to_4x4()
-        )
+        global_matrix = (Matrix.Scale(self.global_scale, 4) @
+                         axis_conversion(to_forward=self.axis_forward,
+                                         to_up=self.axis_up,
+                                         ).to_4x4())
 
         keywords["global_matrix"] = global_matrix
         return export_obj.save(context, **keywords)
@@ -440,7 +476,9 @@ class OBJ_PT_export_transform(bpy.types.Panel):
         layout.prop(operator, 'path_mode')
         layout.prop(operator, 'axis_forward')
         layout.prop(operator, 'axis_up')
-
+        layout.prop(operator, 'global_shift_x')
+        layout.prop(operator, 'global_shift_y')
+        layout.prop(operator, 'global_shift_z')
 
 class OBJ_PT_export_geometry(bpy.types.Panel):
     bl_space_type = 'FILE_BROWSER'
@@ -465,6 +503,8 @@ class OBJ_PT_export_geometry(bpy.types.Panel):
         operator = sfile.active_operator
 
         layout.prop(operator, 'use_mesh_modifiers')
+        # Property definition disabled, not working in 2.8 currently.
+        # layout.prop(operator, 'use_mesh_modifiers_render')
         layout.prop(operator, 'use_smooth_groups')
         layout.prop(operator, 'use_smooth_groups_bitflags')
         layout.prop(operator, 'use_normals')

--- a/io_scene_obj/export_obj.py
+++ b/io_scene_obj/export_obj.py
@@ -764,7 +764,10 @@ def save(context,
          use_selection=True,
          use_animation=False,
          global_matrix=None,
-         path_mode='AUTO'
+         path_mode='AUTO',
+         global_shift_x=0.0,
+         global_shift_y=0.0,
+         global_shift_z=0.0
          ):
 
     _write(context, filepath,

--- a/io_scene_obj/export_obj.py
+++ b/io_scene_obj/export_obj.py
@@ -28,7 +28,7 @@ from bpy_extras.wm_utils.progress_report import (
     ProgressReport,
     ProgressReportSubstep,
 )
-
+import numpy
 
 def name_compat(name):
     if name is None:
@@ -253,6 +253,10 @@ def write_file(filepath, objects, depsgraph, scene,
                EXPORT_GLOBAL_MATRIX=None,
                EXPORT_PATH_MODE='AUTO',
                progress=ProgressReport(),
+               #global_matrix=None,
+               EXPORT_X_SHIFT=0.0,
+               EXPORT_Y_SHIFT=0.0,
+               EXPORT_Z_SHIFT=0.0,
                ):
     """
     Basic write function. The context and options must be already set
@@ -451,8 +455,16 @@ def write_file(filepath, objects, depsgraph, scene,
                         subprogress2.step()
 
                         # Vert
-                        for v in me_verts:
-                            fw('v %.6f %.6f %.6f\n' % v.co[:])
+                        if EXPORT_X_SHIFT != 0.0 or EXPORT_Y_SHIFT != 0.0 or EXPORT_Z_SHIFT != 0.0:
+                            shift = [EXPORT_X_SHIFT,EXPORT_Y_SHIFT,EXPORT_Z_SHIFT]
+                            for v in me_verts:
+                                v.co = numpy.add(v.co,shift)
+                                print(str(v.co))
+                                fw('v %.6f %.6f %.6f\n' % v.co[:])                            
+                        else:
+                            
+                            for v in me_verts:
+                                fw('v %.6f %.6f %.6f\n' % v.co[:])
 
                         subprogress2.step()
 
@@ -672,6 +684,9 @@ def _write(context, filepath,
            EXPORT_ANIMATION,
            EXPORT_GLOBAL_MATRIX,
            EXPORT_PATH_MODE,  # Not used
+           EXPORT_X_SHIFT,
+           EXPORT_Y_SHIFT,
+           EXPORT_Z_SHIFT,
            ):
 
     with ProgressReport(context.window_manager) as progress:
@@ -729,6 +744,9 @@ def _write(context, filepath,
                        EXPORT_GLOBAL_MATRIX,
                        EXPORT_PATH_MODE,
                        progress,
+                       EXPORT_X_SHIFT,
+                       EXPORT_Y_SHIFT,
+                       EXPORT_Z_SHIFT,
                        )
             progress.leave_substeps()
 
@@ -790,6 +808,9 @@ def save(context,
            EXPORT_ANIMATION=use_animation,
            EXPORT_GLOBAL_MATRIX=global_matrix,
            EXPORT_PATH_MODE=path_mode,
+           EXPORT_X_SHIFT=global_shift_x,
+           EXPORT_Y_SHIFT=global_shift_y,
+           EXPORT_Z_SHIFT=global_shift_z,
            )
 
     return {'FINISHED'}

--- a/io_scene_obj/import_obj.py
+++ b/io_scene_obj/import_obj.py
@@ -36,6 +36,7 @@ import os
 import time
 import bpy
 import mathutils
+import numpy
 
 from bpy_extras.io_utils import unpack_list
 from bpy_extras.image_utils import load_image
@@ -913,7 +914,10 @@ def load(context,
          use_image_search=True,
          use_groups_as_vgroups=False,
          relpath=None,
-         global_matrix=None
+         global_matrix=None,
+         global_shift_x=0.0,
+         global_shift_y=0.0,
+         global_shift_z=0.0
          ):
     """
     Called by the user interface or another script.
@@ -1260,7 +1264,9 @@ def load(context,
 
         # Split the mesh by objects/materials, may
         SPLIT_OB_OR_GROUP = bool(use_split_objects or use_split_groups)
-
+        if  global_shift_x != 0.0 or global_shift_y != 0.0 or global_shift_z != 0.0:
+            shift = [global_shift_x,global_shift_y,global_shift_z]
+            verts_loc = numpy.subtract(verts_loc,shift)
         for data in split_mesh(verts_loc, faces, unique_materials, filepath, SPLIT_OB_OR_GROUP):
             verts_loc_split, faces_split, unique_materials_split, dataname, use_vnor, use_vtex = data
             # Create meshes from the data, warning 'vertex_groups' wont support splitting


### PR DESCRIPTION
New feature to import export shifted large coordinates like in the case of geografic coordinates from photogrammetric based 3d models. There are now 3 shifting float values (x,y,z) exposed in the import and in the export panels. These values can be passed with the bpy.ops.import_scene.obj operator as "global_shift_x", "global_shift_x", and "global_shift_x" arguments. The obj importer/exporter  will consider them only if they are not zero values.

This approach enables third parties add-ons to import export with shifted coordinates. Priceless !

I'm not an expert developer so I would like to discuss briefly with original authors if my approach is correct. I tested it with some files and it worked.