### PR TITLE
Fixed gltf export script crashing when selecting Include > Data > Punctual Lights in the export menu.

### DIFF
--- a/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
+++ b/io_scene_gltf2/blender/exp/gltf2_blender_gather_nodes.py
@@ -196,7 +196,7 @@ def __gather_extensions(vnode, export_settings):
         return None
 
     if export_settings["gltf_lights"] and vnode.blender_type == VExportNode.INSTANCE and vnode.data is not None:
-        if vnode.data.type in LIGHTS:
+        if hasattr(vnode.data, 'type') and vnode.data.type in LIGHTS:
             blender_lamp = vnode.data
     elif export_settings["gltf_lights"] and blender_object is not None and (blender_object.type == "LAMP" or blender_object.type == "LIGHT"):
         blender_lamp = blender_object.data


### PR DESCRIPTION
Hello,

the gltf2_blender_gather_nodes.py script crashes at line 188 when including punctual lights because Meshes for example have their "type" variable checked which doesn't seem to exist on meshes.

I added a condition to make the script work.